### PR TITLE
fix extension not starting

### DIFF
--- a/unpacked/index.js
+++ b/unpacked/index.js
@@ -19,13 +19,13 @@ browserApi.storage.onChanged.addListener((changes, area) => {
 });
 
 function start() {
-    if ($('video')) {
+    if ($('#movie_player video')) {
         checkOverlay();
         return;
     }
 
     const documentObserver = new MutationObserver(() => {
-        if ($('video')) {
+        if ($('#movie_player video')) {
             documentObserver.disconnect();
             checkOverlay();
         }

--- a/unpacked/pageAccess.js
+++ b/unpacked/pageAccess.js
@@ -37,7 +37,7 @@ setInterval(() => window._lact = Date.now(), 9e5);
 
 (isMusic ?
     $('#main-panel') :
-    $('.html5-video-player')
+    $('.html5-video-player#movie_player')
 ).onwheel = event => {
     event.preventDefault();
     // Event.deltaY < 0 means wheel-up (increase), > 0 means wheel-down (decrease)


### PR DESCRIPTION
when starting from a channel page that has an intro, the intro has a separate video element which the extension used, now it uses the movie_player element which is the normal video player

fix #13 