### PR TITLE
change default hud style to custom

### DIFF
--- a/unpacked/popup/popup.js
+++ b/unpacked/popup/popup.js
@@ -21,7 +21,7 @@ const activationModifiers = {
 
 const defaultConfig = {
     steps: 1,
-    hud: hudTypes.native,
+    hud: hudTypes.custom,
     hudSize: '50px',
     hudColor: '#eeeeee',
     hudPositionMode: false,


### PR DESCRIPTION
until now, `custom` was the default until the settings were opened for the first time, and then it automatically changed to `native` - which is a weird behavior

now `custom` remains the default even when first opening the settings