### PR TITLE
don't wait for page load if its already loaded + load volume scroll on unstarted/paused videos

### DIFF
--- a/unpacked/index.js
+++ b/unpacked/index.js
@@ -34,13 +34,13 @@ browserApi.storage.onChanged.addListener((changes, area) => {
 });
 
 function start() {
-    if ($('.html5-video-player:not(.unstarted-mode)')) {
+    if ($('.html5-video-player')) {
         checkOverlay();
         return;
     }
 
     const documentObserver = new MutationObserver(() => {
-        if ($('.html5-video-player:not(.unstarted-mode)')) {
+        if ($('.html5-video-player')) {
             documentObserver.disconnect();
             checkOverlay();
         }

--- a/unpacked/index.js
+++ b/unpacked/index.js
@@ -54,10 +54,14 @@ function start() {
 
 // check if the extension is inside a youtube embedded iframe that isn't active yet
 function checkOverlay() {
-    const overlay = $('.ytp-cued-thumbnail-overlay-image');
+    const oldOverlay = $('.ytp-cued-thumbnail-overlay-image');
+    const newOverlay = $('cued-overlay');
     const noOverlay = () =>
-        !overlay?.style.backgroundImage ||
-        overlay.parentNode.style.display === 'none';
+        newOverlay?.classList.contains('ytmCuedOverlayHidden') ||
+        (oldOverlay &&
+            (!oldOverlay.style.backgroundImage ||
+                oldOverlay.parentNode.style.display === 'none')) ||
+        (!newOverlay && !oldOverlay);
     if (noOverlay()) {
         init();
     } else {
@@ -67,10 +71,15 @@ function checkOverlay() {
                 init();
             }
         });
-
-        overlayObserver.observe(overlay.parentNode, {
-            attributeFilter: ['style'],
-        });
+        if (newOverlay) {
+            overlayObserver.observe(newOverlay, {
+                attributeFilter: ['class'],
+            });
+        } else if (oldOverlay?.parentNode) {
+            overlayObserver.observe(oldOverlay.parentNode, {
+                attributeFilter: ['style'],
+            });
+        }
     }
 }
 

--- a/unpacked/index.js
+++ b/unpacked/index.js
@@ -14,8 +14,11 @@ if (browserApi.extension.inIncognitoContext) {
     setupIncognito();
 }
 
-window.addEventListener('load', start, { once: true });
-
+if (document.readyState === 'complete') {
+    start();
+} else {
+    window.addEventListener('load', start, { once: true });
+}
 // keep config in sync with extension popup
 browserApi.storage.onChanged.addListener((changes, area) => {
     // sync is the main storage, local is used for instant changes

--- a/unpacked/pageAccess.js
+++ b/unpacked/pageAccess.js
@@ -927,11 +927,11 @@ class YoutubeVolumeScroll {
 
 ytvs.init();
 
-if (ytvs.$('#movie_player:not(.unstarted-mode) video')) {
+if (ytvs.$('#movie_player video')) {
     YoutubeVolumeScroll.run();
 } else {
     const videoObserver = new MutationObserver(() => {
-        if (ytvs.$('#movie_player:not(.unstarted-mode) video')) {
+        if (ytvs.$('#movie_player video')) {
             videoObserver.disconnect();
             YoutubeVolumeScroll.run();
         }


### PR DESCRIPTION
fix #210

* don't wait for page load if its already loaded
* remove `:unstarted` selector on videos (should start the volume scroll even on paused videos) - hopefully this doesn't cause bugs - i tested it but other setups might have bugs that i can't reproduce
* reworked the overlay listener for embeded videos - it now listen to the new overlay youtube put out in their newest update